### PR TITLE
[WIP] Support events watching from specific contracts

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,6 +88,41 @@ config :slurp,
           ]
         }
       ],
+      {"Approval(address,address,uint256)",
+      [
+        "0xaFF4481D10270F50f203E0763e2597776068CBc5",
+        "0x000000000000000000000000000000000000dead"
+      ]} => [
+        %{
+          enabled: true,
+          struct: Examples.Erc20.Events.Approval,
+          handler: {Examples.EventHandler, :handle_erc20_approval, []},
+          abi: [
+            %{
+              "anonymous" => false,
+              "inputs" => [
+                %{
+                  "indexed" => true,
+                  "name" => "owner",
+                  "type" => "address"
+                },
+                %{
+                  "indexed" => true,
+                  "name" => "spender",
+                  "type" => "address"
+                },
+                %{
+                  "indexed" => false,
+                  "name" => "value",
+                  "type" => "uint256"
+                }
+              ],
+              "name" => "Approval",
+              "type" => "event"
+            }
+          ]
+        }
+      ],
       "Transfer(address,address,uint256)" => [
         %{
           enabled: false,

--- a/config/rinkeby.exs
+++ b/config/rinkeby.exs
@@ -1,0 +1,82 @@
+use Mix.Config
+
+config :logger, backends: [{LoggerFileBackend, :file_log}]
+config :logger, :file_log, path: "./log/#{Mix.env()}.log", metadata: [:blockchain_id]
+
+if System.get_env("DEBUG") == "true" do
+  config :logger, :file_log, level: :debug
+else
+  config :logger, :file_log, level: :info
+end
+
+config :slurp,
+  blockchains: %{
+    "ethereum-rinkeby" => %{
+      start_on_boot: true,
+      name: "Ethereum rinkeby",
+      adapter: Slurp.Adapters.Evm,
+      network_id: 4,
+      chain_id: 1,
+      chain: "ETH",
+      testnet: true,
+      timeout: 5000,
+      new_head_initial_history: 128,
+      poll_interval_ms: 2_500,
+      rpc: [
+        "https://rinkeby-light.eth.linkpool.io"
+      ]
+    }
+  }
+
+config :slurp,
+  new_head_subscriptions: %{
+    "*" => [
+      %{
+        enabled: true,
+        handler: {Examples.NewHeadHandler, :handle_new_head, []}
+      }
+    ]
+  }
+
+
+config :slurp,
+  log_subscriptions: %{
+    "*" => %{
+      # ERC20
+      {"Approval(address,address,uint256)",
+      ["0xaFF4481D10270F50f203E0763e2597776068CBc5",
+       "0x022E292b44B5a146F2e8ee36Ff44D3dd863C915c",
+       "0xc6fDe3FD2Cc2b173aEC24cc3f267cb3Cd78a26B7",
+       "0x1f9061B953bBa0E36BF50F21876132DcF276fC6e"]} => [
+        %{
+          enabled: true,
+          struct: Examples.Erc20.Events.Approval,
+          handler: {Examples.EventHandler, :handle_erc20_approval, []},
+          abi: [
+            %{
+              "anonymous" => false,
+              "inputs" => [
+                %{
+                  "indexed" => true,
+                  "name" => "owner",
+                  "type" => "address"
+                },
+                %{
+                  "indexed" => true,
+                  "name" => "spender",
+                  "type" => "address"
+                },
+                %{
+                  "indexed" => false,
+                  "name" => "value",
+                  "type" => "uint256"
+                }
+              ],
+              "name" => "Approval",
+              "type" => "event"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/examples/event_handler.ex
+++ b/examples/event_handler.ex
@@ -1,8 +1,8 @@
 defmodule Examples.EventHandler do
   require Logger
 
-  def handle_erc20_approval(blockchain, log, event) do
-    handle_event(blockchain, log, event)
+  def handle_erc20_approval(blockchain, log, event, address \\ nil) do
+    handle_event(blockchain, log, event, address)
   end
 
   def handle_erc20_transfer(blockchain, log, event) do
@@ -22,11 +22,11 @@ defmodule Examples.EventHandler do
   end
 
   def handle_uniswap_v2_sync(blockchain, log, event) do
-    handle_event(blockchain,log,  event)
+    handle_event(blockchain,log, event)
   end
 
-  defp handle_event(_blockchain, %{"blockNumber" => hex_block_number}= _log, event) do
+  defp handle_event(_blockchain, %{"blockNumber" => hex_block_number}= _log, event, address \\ nil) do
     {:ok, block_number} = Slurp.Utils.hex_to_integer(hex_block_number)
-    Logger.info "received event: #{inspect event}, block_number: #{block_number}"
+    Logger.info "received event: #{inspect event}, block_number: #{block_number}, address: #{address}"
   end
 end

--- a/lib/slurp/logs/log_fetcher.ex
+++ b/lib/slurp/logs/log_fetcher.ex
@@ -7,6 +7,7 @@ defmodule Slurp.Logs.LogFetcher do
     @type block_number :: Adapter.block_number()
     @type hashed_event_signature :: Adapter.hashed_event_signature()
     @type log_subscription :: Logs.LogSubscription.t()
+    @type address :: String.t()
 
     @type t :: %State{
             blockchain: Blockchains.Blockchain.t(),
@@ -15,10 +16,11 @@ defmodule Slurp.Logs.LogFetcher do
               hashed_event_signature => log_subscription
             },
             topics: [hashed_event_signature],
+            address: [address],
             last_block_number: block_number | nil
           }
 
-    defstruct ~w[blockchain endpoint subscriptions topics last_block_number]a
+    defstruct ~w[blockchain endpoint subscriptions topics address last_block_number]a
   end
 
   @type blockchain :: Blockchains.Blockchain.t()
@@ -29,13 +31,15 @@ defmodule Slurp.Logs.LogFetcher do
   def start_link(blockchain: blockchain, subscriptions: subscriptions) do
     name = process_name(blockchain.id)
     topics = Enum.map(subscriptions, & &1.hashed_event_signature)
+    addresses = Enum.map(subscriptions, & &1.address)
     {:ok, endpoint} = Blockchains.Blockchain.endpoint(blockchain)
 
     state = %State{
       blockchain: blockchain,
       endpoint: endpoint,
       subscriptions: index_subscriptions(subscriptions),
-      topics: topics
+      topics: topics,
+      address: addresses
     }
 
     GenServer.start_link(__MODULE__, state, name: name)
@@ -81,8 +85,14 @@ defmodule Slurp.Logs.LogFetcher do
             with {:ok, event} <-
                    Slurp.Adapter.deserialize_log_event(state.blockchain, log, subscription) do
               {mod, func, extra_args} = subscription.handler
-              args = [state.blockchain, log, event] ++ extra_args
-              apply(mod, func, args)
+              args = [state.blockchain, log, event]
+              if subscription.address != "" do
+                args = args ++ [subscription.address] ++ extra_args
+                apply(mod, func, args)
+              else
+                args = args ++ extra_args
+                apply(mod, func, args)
+              end
             else
               {:error, reason} ->
                 Logger.warn("could not deserialize log event: #{inspect(reason)}")
@@ -133,6 +143,10 @@ defmodule Slurp.Logs.LogFetcher do
       fromBlock: from_hex_block,
       toBlock: to_hex_block
     }
+
+    if length(state.address) > 0 do
+      Map.put(filter, :address, state.address)
+    end
 
     Slurp.Adapter.get_logs(state.blockchain, filter, state.endpoint)
   end

--- a/lib/slurp/logs/log_subscription.ex
+++ b/lib/slurp/logs/log_subscription.ex
@@ -8,7 +8,8 @@ defmodule Slurp.Logs.LogSubscription do
           hashed_event_signature: Slurp.Adapter.hashed_event_signature(),
           struct: module,
           handler: {module, atom, list},
-          abi: [map]
+          abi: [map],
+          address: String.t()
         }
 
   defstruct ~w[
@@ -19,11 +20,12 @@ defmodule Slurp.Logs.LogSubscription do
     struct
     handler
     abi
+    address
   ]a
 
   defimpl Stored.Item do
     def key(log_subscription) do
-      {log_subscription.blockchain_id, log_subscription.event_signature}
+      {log_subscription.blockchain_id, log_subscription.event_signature, log_subscription.address}
     end
   end
 end

--- a/lib/slurp/logs/subscriptions.ex
+++ b/lib/slurp/logs/subscriptions.ex
@@ -28,9 +28,11 @@ defmodule Slurp.Logs.Subscriptions do
         |> Juice.squeeze(blockchains_query)
         |> Enum.flat_map(fn {blockchain_id, blockchain} ->
           events
-          |> Enum.flat_map(fn {event_signature, handlers} ->
+          |> Enum.flat_map(fn {event_header, handlers} ->
             handlers
-            |> Enum.map(fn handler ->
+            |> Enum.flat_map(fn handler ->
+
+              {event_signature, addresses} = parse_event_signature(event_header)
               hashed_event_signature =
                 Slurp.Adapter.hash_event_signature(blockchain, event_signature)
 
@@ -38,15 +40,15 @@ defmodule Slurp.Logs.Subscriptions do
                 Map.merge(handler, %{
                   blockchain_id: blockchain_id,
                   event_signature: event_signature,
-                  hashed_event_signature: hashed_event_signature
+                  hashed_event_signature: hashed_event_signature,
+                  address: addresses
                 })
 
-              struct!(Logs.LogSubscription, attrs)
+              make_log_subscription(attrs)
             end)
           end)
         end)
       end)
-
     {:ok, log_subscriptions}
   end
 
@@ -76,5 +78,21 @@ defmodule Slurp.Logs.Subscriptions do
   @spec put(log_subscription, log_subscription_store_id) :: {:ok, {term, log_subscription}}
   def put(log_subscription, store_id \\ Logs.LogSubscriptionStore.default_store_id()) do
     Logs.LogSubscriptionStore.put(log_subscription, store_id)
+  end
+
+  defp parse_event_signature(signature) when is_bitstring(signature), do: parse_event_signature({signature, []})
+  defp parse_event_signature({event_header, address}), do: {event_header, address}
+
+  defp make_log_subscription(%{address: []} = attrs) do
+    make_log_subscription(%{attrs | address: ""})
+  end
+  defp make_log_subscription(%{address: [address | []]} = attrs) do
+    make_log_subscription(%{attrs | address: address})
+  end
+  defp make_log_subscription(%{address: [address | rest]} = attrs) do
+    make_log_subscription(%{attrs | address: address}) ++ make_log_subscription(%{attrs | address: rest})
+  end
+  defp make_log_subscription(%{address: address} = attrs) when is_bitstring(address) do
+    [struct!(Logs.LogSubscription, attrs)]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Slurp.MixProject do
       {:stored, "~> 0.0.7"},
       {:table_rex, "~> 3.0"},
       {:telemetry, "~> 0.4"},
-      {:logger_file_backend, "~> 0.0.10", only: [:dev, :test]},
+      {:logger_file_backend, "~> 0.0.10", only: [:dev, :test, :rinkeby]},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_unit_notifier, "~> 1.0", only: :test}
@@ -57,6 +57,6 @@ defmodule Slurp.MixProject do
     }
   end
 
-  defp elixirc_paths(env) when env == :test or env == :dev, do: ["lib", "examples"]
+  defp elixirc_paths(env) when env == :test or env == :dev or env == :rinkeby, do: ["lib", "examples"]
   defp elixirc_paths(_), do: ["lib"]
 end


### PR DESCRIPTION
Problem:
* Lacked functionality listen to specific addresses for approvals

Solution:
* Add some logic to make handle it :^) 

should solve most of #4 

Open questions:
* I added a different config file I think is useful as a demonstration / interacting with test networks, let me know if I should remove it.
* These changes lack any testing; I intend to add some tests to at least confirm that the config parser produces the correct results, is there something else I should test aswell?
* address in log_subscription is forced into having empty string as the default case, which avoids doing any address specific logic. is there a better way to handle this? it seems necessary to at least have a default address value, since log_subscriptions ETS storage depends on it to distinguish between different log_subscriptions.